### PR TITLE
fix(build): Add pull_request_target check_approvals guardrails

### DIFF
--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -1,5 +1,6 @@
 name: Black Duck Policy Check
 on:
+  pull_request:
   pull_request_target:
     branches:
       - main
@@ -8,8 +9,31 @@ on:
       - main
 
 jobs:
+  check_approvals:
+    runs-on: ubuntu-latest
+    # Run this job only if the following conditions are met:
+    # 1. The pull request has the 'integration-test' label.
+    # 2. The event is either:
+    #   a. A 'pull_request' event where the base and head repositories are the same (internal PR).
+    #   b. A 'pull_request_target' event where the base and head repositories are different (external PR).
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'integration-test') &&
+      (( github.event_name == 'pull_request' && github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url )) }}
+    outputs:
+      # Output the approval status for pull_request_target events, otherwise default to 'true'
+      check_approvals: ${{ github.event_name == 'pull_request_target' && steps.check_approvals.outputs.check_approvals || 'true' }}
+      # Output whether the PR is external
+      external_pr: ${{ github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url }}
+    steps:
+      - name: Check integration test allowance status
+        # Only run this step for pull_request_target events
+        if: ${{ github.event_name == 'pull_request_target' }}
+        id: check_approvals
+        # Use an external action to check if the PR has the necessary approvals
+        uses: nutanix-cloud-native/action-check-approvals@v1
   security:
-    if: github.repository == 'nutanix-cloud-native/ntnx-api-proxy'
+    needs: check_approvals
+    if: ${{ (github.event_name == 'pull_request' && needs.check_approvals.outputs.external_pr == 'false') || (github.event_name == 'pull_request_target' && needs.check_approvals.outputs.external_pr == 'true' && needs.check_approvals.outputs.check_approvals == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
check_approvals is now used across all pull_request_target workflows.